### PR TITLE
Better customization through use of a specific stylesheet protocol

### DIFF
--- a/Classes/TWMessageBarManager.h
+++ b/Classes/TWMessageBarManager.h
@@ -16,6 +16,38 @@ typedef enum {
     TWMessageBarMessageTypeInfo
 } TWMessageBarMessageType;
 
+@protocol TWMessageBarStyleSheet <NSObject>
+
+/**
+ *  Background color of message view.
+ *
+ *  @param type A MessageBarMessageType (error, information, success, etc).
+ *
+ *  @return UIColor istance representing the message view's background color.
+ */
+- (UIColor *)backgroundColorForMessageType:(TWMessageBarMessageType)type;
+
+/**
+ *  Bottom stroke color of message view.
+ *
+ *  @param type A MessageBarMessageType (error, information, success, etc).
+ *
+ *  @return UIColor istance representing the message view's bottom stroke color.
+ */
+- (UIColor *)strokeColorForMessageType:(TWMessageBarMessageType)type;
+
+/**
+ *  Icon image of the message view.
+ *
+ *  @param type A MessageBarMessageType (error, information, success, etc)
+ *
+ *  @return UIImage istance representing the message view's icon.
+ */
+- (UIImage *)iconImageForMessageType:(TWMessageBarMessageType)type;
+
+@end
+
+
 @interface TWMessageBarManager : NSObject
 
 /**
@@ -24,6 +56,15 @@ typedef enum {
  *  @return MessageBarManager instance (singleton).
  */
 + (TWMessageBarManager *)sharedInstance;
+
+
+/**
+ *  Registers a custom stylesheet subclass on the manager.
+ *  A default class is provided when intialized.
+ *
+ *  @param styleSheet   A custom stylesheet that adheres the TWMessageBarStyleSheet protocol
+ */
+- (void)registerMessageBarStyleSheet:(id<TWMessageBarStyleSheet>)styleSheet;
 
 /**
  *  Shows a message with the supplied title, description and type (dictates color, stroke and icon).
@@ -72,33 +113,5 @@ typedef enum {
 
 @end
 
-@interface TWMessageBarStyleSheet : NSObject
-
-/**
- *  Background color of message view.
- *
- *  @param type A MessageBarMessageType (error, information, success, etc).
- *
- *  @return UIColor istance representing the message view's background color.
- */
-+ (UIColor *)backgroundColorForMessageType:(TWMessageBarMessageType)type;
-
-/**
- *  Bottom stroke color of message view.
- *
- *  @param type A MessageBarMessageType (error, information, success, etc).
- *
- *  @return UIColor istance representing the message view's bottom stroke color.
- */
-+ (UIColor *)strokeColorForMessageType:(TWMessageBarMessageType)type;
-
-/**
- *  Icon image of the message view.
- *
- *  @param type A MessageBarMessageType (error, information, success, etc)
- *
- *  @return UIImage istance representing the message view's icon.
- */
-+ (UIImage *)iconImageForMessageType:(TWMessageBarMessageType)type;
-
+@interface TWMessageBarStyleSheet : NSObject <TWMessageBarStyleSheet>
 @end

--- a/TWMessageBarManager.podspec
+++ b/TWMessageBarManager.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "TWMessageBarManager"
+  s.version      = "1.2.1"
+  s.summary      = "An iOS manager for presenting system-wide notifications via a dropdown message bar."
+  s.homepage     = "https://github.com/terryworona/TWMessageBarManager"
+
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Terry Worona" => "terryworona@gmail.com" }
+  s.source       = { 
+	:git => "https://github.com/terryworona/TWMessageBarManager.git",
+	:tag => "v1.2.1"
+  }
+
+  s.platform = :ios, '6.0'
+  s.source_files = 'Classes', 'Classes/**/*.{h,m}'
+  s.resources = ["Classes/Icons/*.png"]
+  s.requires_arc = true
+end


### PR DESCRIPTION
Hi,
I just came across the lib recently and was playing around with customizing the colors a bit more. Because I like using Cocoapods, I like having the ability to customize the message views without directly altering the original libraries.

This pull request specifies a stylesheet protocol so anyone can pass in an object that conforms to the protocol and change the attributes they want. It also makes it really easy to subclass the default TWMessageBarStyleSheet and only override some of the properties. Trying to change the background color of only one of the message types is as easy as subclassing the TWMessageBarStyleSheet and just calling super for the non-modified types.

I'd be interested to hear what you think, I threw this together pretty quick this afternoon, but it appears to work for me.

I'd be happy to make more changes too.
- JG
