### PR TITLE
Added rotation support by placing the messages in the rootViewController...

### DIFF
--- a/Classes/TWMessageBarManager.m
+++ b/Classes/TWMessageBarManager.m
@@ -144,13 +144,6 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
         _messageBarQueue = [[NSMutableArray alloc] init];
         _messageVisible = NO;
         _styleSheet = [TWDefaultMessageBarStyleSheet styleSheet];
-        
-        _messageWindow = [[TWTouchForwardingWindow alloc] init];
-        _messageWindow.frame = [UIApplication sharedApplication].keyWindow.frame;
-        _messageWindow.hidden = NO;
-        _messageWindow.windowLevel = UIWindowLevelNormal;
-        _messageWindow.backgroundColor = [UIColor clearColor];
-        _messageWindow.rootViewController = [[UIViewController alloc] init];
     }
     return self;
 }
@@ -309,6 +302,16 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 
 - (UIView *)keyWindow
 {
+    if (!_messageWindow)
+    {
+        _messageWindow = [[TWTouchForwardingWindow alloc] init];
+        _messageWindow.frame = [UIApplication sharedApplication].keyWindow.frame;
+        _messageWindow.hidden = NO;
+        _messageWindow.windowLevel = UIWindowLevelNormal;
+        _messageWindow.backgroundColor = [UIColor clearColor];
+        _messageWindow.rootViewController = [[UIViewController alloc] init];
+    }
+    
     return _messageWindow.rootViewController.view;
 }
 


### PR DESCRIPTION
... of their own window. Added rotation notification to resize messages on rotation

These changes add rotation support. For notifications to rotate properly (without resorting to complicated transforms) they need to be a subview of a window's rootViewController. However adding it to the sharedApplication's keyWindow rootViewController causes problems with notifications appearing behind modal controllers that are presented. The best solution is to create another window on top, and add the notifications to it's rootViewController. The last trick is to handle touches for the message views, but pass all other touches to the window below.

This has been tested on iOS 6.1 and 7.1. And works with all rotations on the iPad. I haven't tested rotations on the iPhone, but I don't see why it wouldn't work there as well.

I left the keyWindow naming, although it does now return a view.
