### PR TITLE
[TWMessageBarManager.h] Import UIKit

### DIFF
--- a/Classes/TWMessageBarManager.h
+++ b/Classes/TWMessageBarManager.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 /**
  *  Three base message bar types. Their look & feel is defined within the MessageBarStyleSheet.


### PR DESCRIPTION
Hey,

Since the return type for some of the methods in `TWMessageBarStyleSheet` are `UIColor` and `UIImage`, this file should import `UIKit` (also my project won't compile without this edit).

Thank you so much for open-sourcing this. I find it extremely useful!
