### PR TITLE
Enum changed to NSENUM to support Swift

### DIFF
--- a/Classes/TWMessageBarManager.h
+++ b/Classes/TWMessageBarManager.h
@@ -11,11 +11,11 @@
 /**
  *  Three base message bar types. Their look & feel is defined within the MessageBarStyleSheet.
  */
-typedef enum {
+typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
     TWMessageBarMessageTypeError,
     TWMessageBarMessageTypeSuccess,
     TWMessageBarMessageTypeInfo
-} TWMessageBarMessageType;
+};
 
 @protocol TWMessageBarStyleSheet <NSObject>
 


### PR DESCRIPTION
Solves the issue with TWMessageBarMessageType in Swift. You can now use enum type properly:
.Info
.Success
.Error