### PR TITLE
Add nullability annotations to better support Swift.

### DIFF
--- a/Classes/TWMessageBarManager.h
+++ b/Classes/TWMessageBarManager.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return UIColor istance representing the message view's background color.
  */
-- (UIColor *)backgroundColorForMessageType:(TWMessageBarMessageType)type;
+- (nonnull UIColor *)backgroundColorForMessageType:(TWMessageBarMessageType)type;
 
 /**
  *  Bottom stroke color of message view.
@@ -35,7 +35,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return UIColor istance representing the message view's bottom stroke color.
  */
-- (UIColor *)strokeColorForMessageType:(TWMessageBarMessageType)type;
+- (nonnull UIColor *)strokeColorForMessageType:(TWMessageBarMessageType)type;
 
 /**
  *  Icon image of the message view.
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return UIImage istance representing the message view's icon.
  */
-- (UIImage *)iconImageForMessageType:(TWMessageBarMessageType)type;
+- (nonnull UIImage *)iconImageForMessageType:(TWMessageBarMessageType)type;
 
 @optional
 
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return UIFont instance representing the title font.
  */
-- (UIFont *)titleFontForMessageType:(TWMessageBarMessageType)type;
+- (nonnull UIFont *)titleFontForMessageType:(TWMessageBarMessageType)type;
 
 /**
  *  The (optional) UIFont to be used for the message's description.
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return UIFont instance representing the description font.
  */
-- (UIFont *)descriptionFontForMessageType:(TWMessageBarMessageType)type;
+- (nonnull UIFont *)descriptionFontForMessageType:(TWMessageBarMessageType)type;
 
 /**
  *  The (optional) UIColor to be used for the message's title.
@@ -79,7 +79,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return UIColor instance representing the title color.
  */
-- (UIColor *)titleColorForMessageType:(TWMessageBarMessageType)type;
+- (nonnull UIColor *)titleColorForMessageType:(TWMessageBarMessageType)type;
 
 /**
  *  The (optional) UIColor to be used for the message's description.
@@ -90,7 +90,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return UIColor instance representing the description color.
  */
-- (UIColor *)descriptionColorForMessageType:(TWMessageBarMessageType)type;
+- (nonnull UIColor *)descriptionColorForMessageType:(TWMessageBarMessageType)type;
 
 @end
 
@@ -101,7 +101,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return MessageBarManager instance (singleton).
  */
-+ (TWMessageBarManager *)sharedInstance;
++ (nonnull TWMessageBarManager *)sharedInstance;
 
 /**
  *  Default display duration for each message.
@@ -115,7 +115,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  An object conforming to the TWMessageBarStyleSheet protocol defines the message bar's look and feel.
  *  If no style sheet is supplied, a default class is provided on initialization (see implementation for details).
  */
-@property (nonatomic, strong) NSObject<TWMessageBarStyleSheet> *styleSheet;
+@property (nonnull, nonatomic, strong) NSObject<TWMessageBarStyleSheet> *styleSheet;
 
 /**
  *  Shows a message with the supplied title, description and type.
@@ -124,7 +124,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  @param description  Description text in the message view.
  *  @param type         Type dictates color, stroke and icon shown in the message view.
  */
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type;
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type;
 
 /**
  *  Shows a message with the supplied title, description, type & callback block.
@@ -134,7 +134,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  @param type         Type dictates color, stroke and icon shown in the message view.
  *  @param callback     Callback block to be executed if a message is tapped.
  */
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type callback:(void (^)())callback;
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type callback:(nullable void (^)())callback;
 
 /**
  *  Shows a message with the supplied title, description, type & duration.
@@ -144,7 +144,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  @param type         Type dictates color, stroke and icon shown in the message view.
  *  @param duration     Default duration is 3 seconds, this can be overridden by supplying an optional duration parameter.
  */
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration;
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration;
 
 /**
  *  Shows a message with the supplied title, description, type, duration and callback block.
@@ -155,7 +155,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  @param duration     Default duration is 3 seconds, this can be overridden by supplying an optional duration parameter.
  *  @param callback     Callback block to be executed if a message is tapped.
  */
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration callback:(void (^)())callback;
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration callback:(nullable void (^)())callback;
 
 /**
  *  Shows a message with the supplied title, description, type, status bar style and callback block.
@@ -166,7 +166,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  @param statusBarStyle   Applied during the presentation of the message. If not supplied, style will default to UIStatusBarStyleDefault.
  *  @param callback         Callback block to be executed if a message is tapped.
  */
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type statusBarStyle:(UIStatusBarStyle)statusBarStyle callback:(void (^)())callback;
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type statusBarStyle:(UIStatusBarStyle)statusBarStyle callback:(nullable void (^)())callback;
 
 /**
  *  Shows a message with the supplied title, description, type, duration, status bar style and callback block.
@@ -178,7 +178,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  @param statusBarStyle   Applied during the presentation of the message. If not supplied, style will default to UIStatusBarStyleDefault.
  *  @param callback         Callback block to be executed if a message is tapped.
  */
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration statusBarStyle:(UIStatusBarStyle)statusBarStyle callback:(void (^)())callback;
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration statusBarStyle:(UIStatusBarStyle)statusBarStyle callback:(nullable void (^)())callback;
 
 /**
  *  Shows a message with the supplied title, description, type, status bar hidden toggle and callback block.
@@ -189,7 +189,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  @param statusBarHidden  Status bars are shown by default. To hide it during the presentation of a message, set to NO.
  *  @param callback         Callback block to be executed if a message is tapped.
  */
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type statusBarHidden:(BOOL)statusBarHidden callback:(void (^)())callback;
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type statusBarHidden:(BOOL)statusBarHidden callback:(nullable void (^)())callback;
 
 /**
  *  Shows a message with the supplied title, description, type, duration, status bar hidden toggle and callback block.
@@ -201,7 +201,7 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *  @param statusBarHidden  Status bars are shown by default. To hide it during the presentation of a message, set to NO.
  *  @param callback         Callback block to be executed if a message is tapped.
  */
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration statusBarHidden:(BOOL)statusBarHidden callback:(void (^)())callback;
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration statusBarHidden:(BOOL)statusBarHidden callback:(nullable void (^)())callback;
 
 /**
  *  Hides the topmost message and removes all remaining messages in the queue.
@@ -220,6 +220,6 @@ typedef NS_ENUM(NSInteger, TWMessageBarMessageType) {
  *
  *  @return YES if the device instance is running an OS >= 7, otherwise NO.
  */
-- (BOOL)isRunningiOS7OrLater;
+- (BOOL)tw_isRunningiOS7OrLater;
 
 @end

--- a/Classes/TWMessageBarManager.m
+++ b/Classes/TWMessageBarManager.m
@@ -144,7 +144,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 
 #pragma mark - Singleton
 
-+ (TWMessageBarManager *)sharedInstance
++ (nonnull TWMessageBarManager *)sharedInstance
 {
     static dispatch_once_t pred;
     static TWMessageBarManager *instance = nil;
@@ -182,42 +182,42 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 
 #pragma mark - Public
 
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type
 {
     [self showMessageWithTitle:title description:description type:type duration:[TWMessageBarManager durationForMessageType:type] callback:nil];
 }
 
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type callback:(void (^)())callback
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type callback:(nullable void (^)())callback
 {
     [self showMessageWithTitle:title description:description type:type duration:[TWMessageBarManager durationForMessageType:type] callback:callback];
 }
 
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration
 {
     [self showMessageWithTitle:title description:description type:type duration:duration callback:nil];
 }
 
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration callback:(void (^)())callback
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration callback:(nullable void (^)())callback
 {
     [self showMessageWithTitle:title description:description type:type duration:duration statusBarStyle:UIStatusBarStyleDefault callback:callback];
 }
 
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type statusBarStyle:(UIStatusBarStyle)statusBarStyle callback:(void (^)())callback
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type statusBarStyle:(UIStatusBarStyle)statusBarStyle callback:(nullable void (^)())callback
 {
     [self showMessageWithTitle:title description:description type:type duration:kTWMessageBarManagerDisplayDelay statusBarStyle:statusBarStyle callback:callback];
 }
 
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration statusBarStyle:(UIStatusBarStyle)statusBarStyle callback:(void (^)())callback
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration statusBarStyle:(UIStatusBarStyle)statusBarStyle callback:(nullable void (^)())callback
 {
     [self showMessageWithTitle:title description:description type:type duration:duration statusBarHidden:NO statusBarStyle:statusBarStyle callback:callback];
 }
 
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type statusBarHidden:(BOOL)statusBarHidden callback:(void (^)())callback
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type statusBarHidden:(BOOL)statusBarHidden callback:(nullable void (^)())callback
 {
     [self showMessageWithTitle:title description:description type:type duration:[TWMessageBarManager durationForMessageType:type] statusBarHidden:statusBarHidden statusBarStyle:UIStatusBarStyleDefault callback:callback];
 }
 
-- (void)showMessageWithTitle:(NSString *)title description:(NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration statusBarHidden:(BOOL)statusBarHidden callback:(void (^)())callback
+- (void)showMessageWithTitle:(nullable NSString *)title description:(nullable NSString *)description type:(TWMessageBarMessageType)type duration:(CGFloat)duration statusBarHidden:(BOOL)statusBarHidden callback:(nullable void (^)())callback
 {
     [self showMessageWithTitle:title description:description type:type duration:duration statusBarHidden:statusBarHidden statusBarStyle:UIStatusBarStyleDefault callback:callback];
 }
@@ -552,7 +552,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
             yOffset = ceil(rect.size.height * 0.5) - ceil(titleLabelSize.height * 0.5) - kTWMessageViewTextOffset;
         }
         
-        if ([[UIDevice currentDevice] isRunningiOS7OrLater])
+        if ([[UIDevice currentDevice] tw_isRunningiOS7OrLater])
         {
             NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
             paragraphStyle.alignment = NSTextAlignmentLeft;
@@ -606,7 +606,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 
 - (CGFloat)statusBarOffset
 {
-    return [[UIDevice currentDevice] isRunningiOS7OrLater] ? [self statusBarFrame].size.height : 0.0;
+    return [[UIDevice currentDevice] tw_isRunningiOS7OrLater] ? [self statusBarFrame].size.height : 0.0;
 }
 
 - (CGFloat)availableWidth
@@ -619,7 +619,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
     CGSize boundedSize = CGSizeMake([self availableWidth], CGFLOAT_MAX);
     CGSize titleLabelSize;
     
-    if ([[UIDevice currentDevice] isRunningiOS7OrLater])
+    if ([[UIDevice currentDevice] tw_isRunningiOS7OrLater])
     {
         NSDictionary *titleStringAttributes = [NSDictionary dictionaryWithObject:[self titleFont] forKey: NSFontAttributeName];
         titleLabelSize = [self.titleString boundingRectWithSize:boundedSize
@@ -643,7 +643,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
     CGSize boundedSize = CGSizeMake([self availableWidth], CGFLOAT_MAX);
     CGSize descriptionLabelSize;
     
-    if ([[UIDevice currentDevice] isRunningiOS7OrLater])
+    if ([[UIDevice currentDevice] tw_isRunningiOS7OrLater])
     {
         NSDictionary *descriptionStringAttributes = [NSDictionary dictionaryWithObject:[self descriptionFont] forKey: NSFontAttributeName];
         descriptionLabelSize = [self.descriptionString boundingRectWithSize:boundedSize
@@ -772,7 +772,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 
 #pragma mark - TWMessageBarStyleSheet
 
-- (UIColor *)backgroundColorForMessageType:(TWMessageBarMessageType)type
+- (nonnull UIColor *)backgroundColorForMessageType:(TWMessageBarMessageType)type
 {
     UIColor *backgroundColor = nil;
     switch (type)
@@ -786,13 +786,11 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
         case TWMessageBarMessageTypeInfo:
             backgroundColor = kTWDefaultMessageBarStyleSheetInfoBackgroundColor;
             break;
-        default:
-            break;
     }
     return backgroundColor;
 }
 
-- (UIColor *)strokeColorForMessageType:(TWMessageBarMessageType)type
+- (nonnull UIColor *)strokeColorForMessageType:(TWMessageBarMessageType)type
 {
     UIColor *strokeColor = nil;
     switch (type)
@@ -806,13 +804,11 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
         case TWMessageBarMessageTypeInfo:
             strokeColor = kTWDefaultMessageBarStyleSheetInfoStrokeColor;
             break;
-        default:
-            break;
     }
     return strokeColor;
 }
 
-- (UIImage *)iconImageForMessageType:(TWMessageBarMessageType)type
+- (nonnull UIImage *)iconImageForMessageType:(TWMessageBarMessageType)type
 {
     UIImage *iconImage = nil;
     switch (type)
@@ -825,8 +821,6 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
             break;
         case TWMessageBarMessageTypeInfo:
             iconImage = [UIImage imageNamed:kTWMessageBarStyleSheetImageIconInfo];
-            break;
-        default:
             break;
     }
     return iconImage;
@@ -860,7 +854,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 
 #pragma mark - OS Helpers
 
-- (BOOL)isRunningiOS7OrLater
+- (BOOL)tw_isRunningiOS7OrLater
 {
     NSString *systemVersion = self.systemVersion;
     NSUInteger systemInt = [systemVersion intValue];
@@ -877,7 +871,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 {
     _statusBarStyle = statusBarStyle;
     
-    if ([[UIDevice currentDevice] isRunningiOS7OrLater])
+    if ([[UIDevice currentDevice] tw_isRunningiOS7OrLater])
     {
         [self setNeedsStatusBarAppearanceUpdate];
     }
@@ -887,7 +881,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 {
     _statusBarHidden = statusBarHidden;
 
-    if ([[UIDevice currentDevice] isRunningiOS7OrLater])
+    if ([[UIDevice currentDevice] tw_isRunningiOS7OrLater])
     {
         [self setNeedsStatusBarAppearanceUpdate];
     }


### PR DESCRIPTION
- Added nullability annotations to better support Swift projects.
- Prefixed `isRunningiOS7OrLater` category to avoid any collisions
- Removed default cases on switching on enum so if future enums are added, compiler will give some warnings. No warnings now since the switch is exhaustive.