### PR TITLE
Bugfix: Messages created from a message callback won't appear

### DIFF
--- a/Classes/TWMessageBarManager.m
+++ b/Classes/TWMessageBarManager.m
@@ -347,9 +347,6 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
         [UIView animateWithDuration:kTWMessageBarManagerDismissAnimationDuration animations:^{
             [messageView setFrame:CGRectMake(messageView.frame.origin.x, messageView.frame.origin.y - [messageView height], [messageView width], [messageView height])]; // slide back up
         } completion:^(BOOL finished) {
-            self.messageVisible = NO;
-            [messageView removeFromSuperview];
-            
             if (itemHit)
             {
                 if ([messageView.callbacks count] > 0)
@@ -361,6 +358,9 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
                     }
                 }
             }
+            
+            self.messageVisible = NO;
+            [messageView removeFromSuperview];
             
             if([self.messageBarQueue count] > 0)
             {


### PR DESCRIPTION
This happened due to the fact that selecting a message will set the "messageVisible" boolean property to NO before calling the callback. When a new message get's presented, this message will be instantly shown, due to the "messageVisible" property being NO. If no further message
is queued, the messageWindow will be set to nil and the callback message never shows up.

This can be fixed by setting "messageVisible" to NO after calling the callback, to avoid that the message will be shown instantly and instead remains in the queue.