### PR TITLE
Load icon images from framework bundle

### DIFF
--- a/Classes/TWMessageBarManager.m
+++ b/Classes/TWMessageBarManager.m
@@ -807,16 +807,23 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 - (nonnull UIImage *)iconImageForMessageType:(TWMessageBarMessageType)type
 {
     UIImage *iconImage = nil;
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     switch (type)
     {
         case TWMessageBarMessageTypeError:
-            iconImage = [UIImage imageNamed:kTWMessageBarStyleSheetImageIconError];
+            iconImage = [UIImage imageNamed:kTWMessageBarStyleSheetImageIconError
+                                   inBundle:bundle
+              compatibleWithTraitCollection:nil];
             break;
         case TWMessageBarMessageTypeSuccess:
-            iconImage = [UIImage imageNamed:kTWMessageBarStyleSheetImageIconSuccess];
+            iconImage = [UIImage imageNamed:kTWMessageBarStyleSheetImageIconSuccess
+                                   inBundle:bundle
+              compatibleWithTraitCollection:nil];
             break;
         case TWMessageBarMessageTypeInfo:
-            iconImage = [UIImage imageNamed:kTWMessageBarStyleSheetImageIconInfo];
+            iconImage = [UIImage imageNamed:kTWMessageBarStyleSheetImageIconInfo
+                                   inBundle:bundle
+              compatibleWithTraitCollection:nil];
             break;
     }
     return iconImage;


### PR DESCRIPTION
If integrating through cocoapods using frameworks, it will not load the icon images properly, since `[UIImage imageNamed:@""]` looks at the main bundle.

With this changes it will look at the appropriate bundle and work if using `TWMessageBarManager` from a framework or not